### PR TITLE
Add :status to %Whois.Record{}

### DIFF
--- a/lib/whois.ex
+++ b/lib/whois.ex
@@ -34,6 +34,9 @@ defmodule Whois do
             nil ->
               {:ok, raw}
 
+            "" ->
+              {:ok, raw}
+
             ^host ->
               {:ok, raw}
 

--- a/lib/whois.ex
+++ b/lib/whois.ex
@@ -34,9 +34,6 @@ defmodule Whois do
             nil ->
               {:ok, raw}
 
-            "" ->
-              {:ok, raw}
-
             ^host ->
               {:ok, raw}
 

--- a/test/whois/record_test.exs
+++ b/test/whois/record_test.exs
@@ -15,6 +15,15 @@ defmodule Whois.RecordTest do
              "ns4.google.com"
            ]
 
+    assert record.status == [
+             "clientDeleteProhibited",
+             "clientTransferProhibited",
+             "clientUpdateProhibited",
+             "serverDeleteProhibited",
+             "serverTransferProhibited",
+             "serverUpdateProhibited"
+           ]
+
     assert record.registrar == "MarkMonitor, Inc."
     assert_dt(record.created_at, ~D[1997-09-15])
     assert_dt(record.updated_at, ~D[2017-09-07])
@@ -32,6 +41,15 @@ defmodule Whois.RecordTest do
              "ns4.google.net"
            ]
 
+    assert record.status == [
+             "clientDeleteProhibited",
+             "clientTransferProhibited",
+             "clientUpdateProhibited",
+             "serverDeleteProhibited",
+             "serverTransferProhibited",
+             "serverUpdateProhibited"
+           ]
+
     assert record.registrar == "MarkMonitor, Inc."
     assert_dt(record.created_at, ~D[1999-03-15])
     assert_dt(record.updated_at, ~D[2017-09-08])
@@ -47,6 +65,15 @@ defmodule Whois.RecordTest do
              "ns2.google.com",
              "ns3.google.com",
              "ns4.google.com"
+           ]
+
+    assert record.status == [
+             "clientDeleteProhibited",
+             "clientTransferProhibited",
+             "clientUpdateProhibited",
+             "serverDeleteProhibited",
+             "serverTransferProhibited",
+             "serverUpdateProhibited"
            ]
 
     assert record.registrar == "MarkMonitor, Inc."


### PR DESCRIPTION
Adds :status field to %Whois.Record{} struct. The `status` of a domain name is important as it can tell if the domain name can be transferred (`clientTransferProhibited`), if it's expired (`redemptionPeriod`), if it's about to be deleted (`pendingDelete`) etc.