### PR TITLE
Gracefully handle connection timeouts for registrars that point to non-functional WHOIS servers

### DIFF
--- a/test/whois_test.exs
+++ b/test/whois_test.exs
@@ -78,6 +78,16 @@ defmodule WhoisTest do
     assert %NaiveDateTime{} = record.expires_at
   end
 
+  @tag :live
+  test "lookup/1 can deal with domains that incorrectly point to fake WHOIS servers" do
+    assert {:ok, record} = Whois.lookup("storehub.io", recv_timeout: 5_000)
+    assert record.domain == "storehub.io"
+    assert record.registrar == "Pair Domains"
+    assert record.created_at == ~N[2019-09-12 10:17:27]
+    assert %NaiveDateTime{} = record.updated_at
+    assert %NaiveDateTime{} = record.expires_at
+  end
+
   defp wait, do: Process.sleep(2500)
 end
 


### PR DESCRIPTION
This fixes an issue see with the `pairdomains.com` registrar, whose WHOIS record terminate with a record that includes this:

```
    Registrar WHOIS Server: pairdomains.com
```

The actual WHOIS server for the registrar is `whois.pairdomains.com`, so prior to this patch, `Whois.lookup/1` would fail after 60 seconds with `{:error, :timed_out}`. Now, we'll fall back to the most recent successfully retrieved record after `:connect_timeout` (10 seconds by default).