### PR TITLE
fix .me issue

### DIFF
--- a/lib/whois.ex
+++ b/lib/whois.ex
@@ -146,9 +146,9 @@ defmodule Whois do
       |> String.trim()
       |> String.downcase()
       |> case do
-        "whois:" <> host -> String.trim(host)
-        "whois server:" <> host -> String.trim(host)
-        "registrar whois server:" <> host -> String.trim(host)
+        "whois:" <> host when host != "" -> String.trim(host)
+        "whois server:" <> host when host != "" -> String.trim(host)
+        "registrar whois server:" <> host when host != "" -> String.trim(host)
         _ -> nil
       end
     end)


### PR DESCRIPTION
Looks like that for some domains like .me because it's providing the fields empty it's failing. This PR helps avoid that.