### PR TITLE
Update registry for .in domains

### DIFF
--- a/priv/tld.csv
+++ b/priv/tld.csv
@@ -540,7 +540,7 @@ imamat,whois.afilias-srs.net
 imdb,whois.nic.imdb
 immo,whois.nic.immo
 immobilien,whois.nic.immobilien
-in,whois.registry.in
+in,whois.nixiregistry.in
 inc,whois.nic.inc
 industries,whois.nic.industries
 infiniti,whois.nic.gmo


### PR DESCRIPTION
The Registry for indian `.in` domains seems to have changed from `whois.registry.in` to `whois.nixiregistry.in`

